### PR TITLE
Typo and formatting fixes

### DIFF
--- a/data/api/ui.layout_type_config.md
+++ b/data/api/ui.layout_type_config.md
@@ -7,19 +7,19 @@ type
     
 @type: string 
 @values:
-- line	cells with the border (default)
-- clean	cells without the border
-- wide	cells with the border and small space between siblings
-- space  cells with the border and wide space between siblings
-- head  similar to "wide", but there is no any border between the first and second cells
+- line	cells with border (default)
+- clean	cells without border
+- wide	cells with border and small space between siblings
+- space	cells with border and wide space between siblings
+- head	similar to "wide", but there is any border between the first and second cells
     
 @example:
 
 webix.ui({
-	type:"space", 
-    rows:[
-		...
-	]
+    type: 'space',
+    rows: [
+        ...
+        ]
 });
 
 @template:	api_config


### PR DESCRIPTION
Thanks for putting the docs on GitHub!

Note on this page: in the list of @values, there are two columns on the [live page](http://docs.webix.com/api__ui.layout_type_config.html) right now:

![image](https://cloud.githubusercontent.com/assets/33569/5707834/d3aa3a0e-9a40-11e4-9acd-33ad792be788.png)

Will these two columns be preserved by the Tab character between the first and the second column in the markup, or is some special formatting required?