### PR TITLE
Proofreading, mostly for dynamic data loading

### DIFF
--- a/data/api/_ready.md
+++ b/data/api/_ready.md
@@ -3,21 +3,21 @@ ready
 
 
 @short: event handler called just after the page has been completely parsed.
-	
+
 
 @params:
 - code		function		event handler code
 
 
 @example:
-webix.ready(function (){
-	webix.ui({
-		container: "box",
-		view: "window",
-		...
-	});
-	...
-})
+webix.ready(function () {
+  webix.ui({
+    container: "box",
+    view: "window",
+    ...
+  });
+  ...
+});
 
 
 @relatedapi: api/dataloader_ready_config.md

--- a/data/api/atomdataloader_datafeed_config.md
+++ b/data/api/atomdataloader_datafeed_config.md
@@ -8,21 +8,21 @@ dataFeed
 @type: string, function
 @example:
 var myform = new webix.ui({
-    container: "box",
-    view: "form",
-    ...  
-    dataFeed: "data/form.php"
+  container: "box",
+  view: "form",
+  ...
+  dataFeed: "data/form.php"
 });
 myform.bind(mygrid);
 
 @template:	api_config
-@defined:	DataLoader	
+@defined:	DataLoader
 @relatedapi:
 	api/basebind_bind.md
-    api/atomrender_sync.md
+	api/atomrender_sync.md
 @related: 
 	desktop/binding_details.md
-    desktop/data_loading.md
+	desktop/data_loading.md
 @descr:
 
 ###Using during binding 
@@ -55,14 +55,14 @@ In the code below, the [suggest](desktop/suggest.md) component linked to an inpu
 
 ~~~js
 webix.ui({
-	view: "suggest",
-	keyPressTimeout: "1000",
-	input: $$("text_search"),
-	body: {
-   		dataFeed: function (text) {
-        	this.clearAll();
-        	this.load("data/search/" + text);
-    	}
-	}
+  view: "suggest",
+  keyPressTimeout: "1000",
+  input: $$("text_search"),
+  body: {
+    dataFeed: function (text) {
+      this.clearAll();
+      this.load("data/search/" + text);
+    }
+  }
 });
 ~~~

--- a/data/api/collectionbind_setcursor.md
+++ b/data/api/collectionbind_setcursor.md
@@ -7,15 +7,16 @@ setCursor
 
 @params:
 - cursor      id      the cursor position
-	
+
 
 @example:
 var data = new webix.DataCollection({ 
-		..//collection config
-	});
+  ...  // collection config
+});
 
-$$('list').attachEvent("onAfterSelect", function(id){  
-		data.setCursor(id); 
+$$('list').attachEvent("onAfterSelect", function (id) {
+  data.setCursor(id);
+});
 
 @relatedapi:
 	api/CollectionBind_getCursor.md
@@ -24,7 +25,7 @@ $$('list').attachEvent("onAfterSelect", function(id){
 @relatedsample:
 	80_docs/nonui.html
 @template:	api_method
-@defined:	CollectionBind	
+@defined:	CollectionBind
 @descr:
 
 

--- a/data/api/contexthelper_body_config.md
+++ b/data/api/contexthelper_body_config.md
@@ -2,23 +2,23 @@ body
 ====
 
 @short: the contents of the context popup window
-	
+
 
 @type: object
 @example:
 
 webix.ui({
-	view: "context",
-	body: {  },
-	...  // context config
+  view: "context",
+  body: {  },
+  ...  // context config
 });
 
 @template:	api_config
-@related:	
+@related:
 	desktop/context.md
 @relatedsample:
 	03_menu/05_context_content.html
-    03_menu/07_context_ui.html
+	03_menu/07_context_ui.html
 @descr:
 
 The `body` property of a context popup menu may contain HTML code as well as Webix components.
@@ -39,12 +39,12 @@ webix.ui({
 
 ~~~js
 webix.ui({
-	view: "context",
-	body: {
-     view: "toolbar", cols: [
-		   { view: "button", value: "Button1", width: 100 },
-		   { view: "button", value: "Button2", width: 100 },
-		 ]
-	}
+  view: "context",
+  body: {
+    view: "toolbar", cols: [
+      { view: "button", value: "Button1", width: 100 },
+      { view: "button", value: "Button2", width: 100 },
+    ]
+  }
 });
 ~~~

--- a/data/api/selectionmodel_onafterselect_event.md
+++ b/data/api/selectionmodel_onafterselect_event.md
@@ -9,9 +9,9 @@ onAfterSelect
 - id		id		the id of an item
 
 @example: 
-	
-some.attachEvent("onAfterSelect", function(id){
-    //... some code here ... 
+
+some.attachEvent("onAfterSelect", function (id) {
+  // ... some code here ...
 });
 
 @template:	api_event
@@ -20,15 +20,11 @@ some.attachEvent("onAfterSelect", function(id){
 	api/selectionmodel_onbeforeselect_event.md
 @related: 
 	desktop/selection.md
-	
+
 @descr:
 
-In case of the multiselect mode enabled, the event will fire: 
+If multiselect mode is enabled, the event will fire only when additional items are selected with Ctrl+click, while passing the ID of a recently selected item.
+The event wil not fire when the selection is extended via Shift+click.
 
-- Ctrl+click: each time an item is selected while passing the ID of a recently selected item;
-- Shift+click: will not fire. 
-
-It is safer to use the api/selectionmodel_onselectchange_event.md event that catches all changes of selection state in the component
+It is safer to use the api/selectionmodel_onselectchange_event.md event, which catches all selection state changes in the component,
 combined with the api/selectionmodel_getselectedid.md method.
-
-

--- a/data/api/selectionmodel_onbeforeselect_event.md
+++ b/data/api/selectionmodel_onbeforeselect_event.md
@@ -7,12 +7,12 @@ onBeforeSelect
 
 @params:
 - id		id		id of item
-- selection	bool		true if we select, false if unselect
+- selection	bool		true if the item was selected, false if it was unselected
 
 @example: 
-	
-some.attachEvent("onBeforeSelect", function(id, selection){
-    //... some code here ... 
+
+some.attachEvent("onBeforeSelect", function (id, selection){
+  // ... some code here ...
 });
 
 @template:	api_event
@@ -21,7 +21,5 @@ some.attachEvent("onBeforeSelect", function(id, selection){
 	api/selectionmodel_onafterselect_event.md
 @related: 
 	desktop/selection.md
-	
+
 @descr:
-
-

--- a/data/api/selectionmodel_onselectchange_event.md
+++ b/data/api/selectionmodel_onselectchange_event.md
@@ -10,13 +10,13 @@ onSelectChange
 
 @example: 
 webix.ui({
-	view:"datatable",
-	on:{
-		onSelectChange:function(){
-			var text = "Selected: "+grid.getSelection(true).join();
-			document.getElementById('testB').innerHTML = text;
-		}
-	}
+  view: "datatable",
+  on: {
+    onSelectChange:function () {
+      var text = "Selected: " + grid.getSelectedId(true).join();
+      document.getElementById('testB').innerHTML = text;
+    }
+  }
 });
 @template:	api_event
 @defined:	SelectionModel
@@ -24,7 +24,5 @@ webix.ui({
 	desktop/selection.md
 @relatedsample:
 	15_datatable/05_selection/08_block_selection.html
-    06_dataview/01_initialization/01_init.html
+	06_dataview/01_initialization/01_init.html
 @descr:
-
-

--- a/data/api/ui.datatable_onafterselect_event.md
+++ b/data/api/ui.datatable_onafterselect_event.md
@@ -6,13 +6,13 @@ onAfterSelect
 	fires after a cell is selected
 
 @params:
-- data		object		the selected object
-- preserve    bool    indicates whether the previous selection state should be saved
+- data        object    the selected object
+- preserve    bool      indicates whether the previous selection state should be saved
 
 @example: 
-	
-some.attachEvent("onAfterSelect", function(data, preserve){
-    //... some code here ... 
+
+some.attachEvent("onAfterSelect", function (data, preserve){
+  //... some code here ...
 });
 
 @template:	api_event
@@ -21,25 +21,21 @@ some.attachEvent("onAfterSelect", function(data, preserve){
 	datatable/selection.md
 @relatedapi:
 	api/ui.datatable_onbeforeselect_event.md
-    api/ui.datatable_onselectchange_event.md
+	api/ui.datatable_onselectchange_event.md
 	api/ui.datatable_selectrange.md
 	api/ui.datatable_getselectedid.md
-    api/ui.datatable_mapselection.md
-    api/ui.datatable_unselect.md
-    api/ui.datatable_clearselection.md
-	
-	
+	api/ui.datatable_mapselection.md
+	api/ui.datatable_unselect.md
+	api/ui.datatable_clearselection.md
+
 @descr:
 
-In case of a api/ui.datatable_multiselect_config.md mode enabled, the event will fire: 
+If api/ui.datatable_multiselect_config.md mode is enabled, the event will fire:
 
 - Each time you select an item with Ctrl+click;
 - Once for each selected item in the group during Shift+click selection. 
 
-Every time the ID of a newly selected item will come into the event. 
+In each case, the ID of the newly selected item be passed to the event.
 
 To get the IDs of currently selected items, you can use a combination of api/ui.datatable_onselectchange_event.md
-and api/ui.datatable_selectrange.md method. 
-
-
-
+and the api/ui.datatable_selectrange.md method.

--- a/data/api/ui.datatable_onbeforeselect_event.md
+++ b/data/api/ui.datatable_onbeforeselect_event.md
@@ -5,31 +5,30 @@ onBeforeSelect
 	fires before a cell is selected
 
 @params:
-- data		object		the selected object
-- preserve    bool    indicates whether the previous selection will be saved
+- data        object    the selected object
+- preserve    bool      indicates whether the previous selection will be saved
 
 @returns:
-- result  bool  returning <i>false</i> will prevent item selection
+- result  bool  returning `false` will prevent item selection
 
 @example: 
 	
-some.attachEvent("onBeforeSelect", function(data, preserve){
-    //... some code here ... 
-    //return false to block operation
-    return true;
+some.attachEvent("onBeforeSelect", function (data, preserve){
+  // ... some code here ...
+  // return false to block operation
+  return true;
 });
 
 @template:	api_event
 
 @related:
-	datatable/selection.md
+    datatable/selection.md
 @relatedapi:
-	api/ui.datatable_onafterselect_event.md
-	api/ui.datatable_selectrange.md
-	api/ui.datatable_getselectedid.md
+    api/ui.datatable_onafterselect_event.md
+    api/ui.datatable_selectrange.md
+    api/ui.datatable_getselectedid.md
     api/ui.datatable_mapselection.md
     api/ui.datatable_unselect.md
     api/ui.datatable_clearselection.md
-	
-@descr:
 
+@descr:

--- a/data/api/ui.datatable_onselectchange_event.md
+++ b/data/api/ui.datatable_onselectchange_event.md
@@ -1,36 +1,35 @@
 onSelectChange
-=============
+==============
 
 
-@short: fires when selection is changed in DataTable
-	
+@short: fires when selection is changed in a DataTable
+
 @example:
 
 webix.ui({
-    view:"datatable",
-    on:{
-        onSelectChange:function(){
-            var text = "Selected: "+grid.getSelection(true).join();
-            document.getElementById('testB').innerHTML = text;
-        }
-    }
+  view: "datatable",
+  on: {
+     onSelectChange: function () {
+       var text = "Selected: " + grid.getSelection(true).join();
+       document.getElementById('testB').innerHTML = text;
+     }
+  }
 });
 
 @template:	api_event
 
 @related:
-	datatable/selection.md
+    datatable/selection.md
 @relatedsample: 
     15_datatable/05_selection/08_block_selection.html
 @relatedapi:
-	api/ui.datatable_onafterselect_event.md
+    api/ui.datatable_onafterselect_event.md
     api/ui.datatable_onbeforeselect_event.md
-	api/ui.datatable_selectrange.md
-	api/ui.datatable_getselectedid.md
+    api/ui.datatable_selectrange.md
+    api/ui.datatable_getselectedid.md
     api/ui.datatable_mapselection.md
     api/ui.datatable_unselect.md
     api/ui.datatable_clearselection.md
 @descr:
 
-The event doesn't provide any details about changes, just informs about the fact.
-
+The event doesn't provide any details about changes; it just informs that it has occurred.

--- a/data/api/ui.datatable_onselectchange_event.md
+++ b/data/api/ui.datatable_onselectchange_event.md
@@ -10,7 +10,7 @@ webix.ui({
   view: "datatable",
   on: {
      onSelectChange: function () {
-       var text = "Selected: " + grid.getSelection(true).join();
+       var text = "Selected: " + grid.getSelectedId(true).join();
        document.getElementById('testB').innerHTML = text;
      }
   }

--- a/data/datatable/editing.md
+++ b/data/datatable/editing.md
@@ -9,9 +9,9 @@ Making DataTable editable
 }}
 ~~~js
 dtable = new webix.ui({
-	view:"datatable",
-	...
-	editable:true
+  view: "datatable",
+  ...
+  editable:true
 });
 ~~~
 {{sample 15_datatable/04_editing/01_basic.html }}
@@ -41,8 +41,8 @@ To assign the needed editor type to a column, you should specify attribute **edi
 Specifying the editor for a column
 }}
 ~~~js
-columns:[
-	{ id:"title", header:"Film title", editor:"text"}
+columns: [
+  { id:"title", header:"Film title", editor:"text"}
 ]
 ~~~
 {{sample 15_datatable/04_editing/01_basic.html }}
@@ -59,13 +59,13 @@ To create a custom editor, you should set the following methods to it:
 - **render()** - renders the editor.
 
 webix.editors = {
-    "myeditor":{
-		focus:function(){...}
-        getValue:function(){...},
-        setValue:function(value){...},
-        render:function(){...}
-     }
-  };
+  "myeditor": {
+    focus: function () {...}
+    getValue: function () {...},
+    setValue: function (value) {...},
+    render: function () {...}
+  }
+};
 
 The functions are defines with the help of the following inner properties: 
 
@@ -82,11 +82,11 @@ Adding a new editor and setting it for the column
 }}
 ~~~js
 webix.ui({
-	view:"datatable",
-	columns:[
-	...
-		{ id:"title", header:"Film title", editor:"myeditor"}
-	]
+  view: "datatable",
+  columns: [
+    ...
+    { id: "title", header: "Film title", editor: "myeditor"}
+  ]
 });
 ~~~
 
@@ -104,10 +104,10 @@ Opening editors on a double click
 }}
 ~~~js
 webix.ui({
-    view:"datatable",
-    editable:true,
-    editaction:"dblclick"
-    ...
+  view: "datatable",
+  editable: true,
+  editaction: "dblclick"
+  ...
 });
 ~~~
 
@@ -126,10 +126,10 @@ Opening editors on the Enter key press
 }}
 ~~~js
 var mytable = new webix.ui({
-	view:"datatable",
-	...
-    editable:true,
-    editaction:"custom"
+  view: "datatable",
+  ...
+  editable: true,
+  editaction: "custom"
 });
 
 
@@ -152,16 +152,16 @@ Opening editors on cell selecting
 }}
 ~~~js
 var mytable = new webix.ui({
-	view:"datatable",
-	...
-    editable:true,
-    editaction:"custom",
-    select:"cell",
-	on:{
-		"onAfterSelect":function(data,prevent){
-			this.editCell(data.row, data.column);
-		}
-	}
+  view: "datatable",
+  ...
+  editable:true,
+  editaction: "custom",
+  select: "cell",
+  on:{
+    onAfterSelect: function (data,prevent) {
+      this.editCell(data.row, data.column);
+    }
+  }
 })
 ~~~
 
@@ -182,28 +182,28 @@ Opening editors in all cells of the row, column
 ~~~js
 //editing the entire row
 var table1 = new webix.ui({
-	view:"datatable",
-	...
-    editable:true,
-    editaction:"custom",
-	on:{
-		"onItemClick":function(id){
-			this.editRow(id);
-		}
-	}
+  view: "datatable",
+  ...
+  editable: true,
+  editaction: "custom",
+  on: {
+    onItemClick: function (id) {
+      this.editRow(id);
+    }
+  }
 });
 
 //editing the entire column
 var table2 = new webix.ui({
-	view:"datatable",
-	...
-    editable:true,
-    editaction:"custom",
-	on:{
-		"onItemClick":function(id){
-			this.editColumn(id);
-		}
-	}
+  view:"datatable",
+  ...
+  editable: true,
+  editaction: "custom",
+  on: {
+    onItemClick: function(id){
+      this.editColumn(id);
+    }
+  }
 })
 ~~~
 
@@ -252,4 +252,3 @@ By default, the Tab(Tab+Shift) key(s) allows navigating within editors defined i
 {{sample 15_datatable/04_editing/28_scroll.html }}
 
 {{sample 15_datatable/04_editing/03_multiple_editors.html }}
-

--- a/data/datatable/events_handling.md
+++ b/data/datatable/events_handling.md
@@ -1,6 +1,6 @@
 
-Events Handling with Datatable
-=============================
+Events Handling with DataTable
+==============================
 
 You can assign a custom behavior to different events of DataTable by using its event handling system.
 
@@ -22,12 +22,13 @@ You can attach several handlers to the same event and detach them using two resp
 A general way to attach/detach the event handler
 }}
 ~~~js
-//to attach event
-		var myEvent = $$("dataTableId").attachEvent("onItemClick", function (){
-			//event handler code
-		})
-//to detach event
-		$$("dataTableId").detachEvent(myEvent);
+// to attach event
+var myEvent = $$("dataTableId").attachEvent("onItemClick", function () {
+  // event handler code
+})
+
+// to detach event
+$$("dataTableId").detachEvent(myEvent);
 ~~~
 
 Parameter 'on'
@@ -39,9 +40,9 @@ Attaching the event handler through parameter 'on'
 }}
 ~~~js
 webix.ui({
-	 view:"dataTable", 
-         ...
-	 on:{"itemClick": function(){alert("item has just been clicked");}}
+  view: "dataTable",
+  ...
+  on: {"itemClick": function () {alert("item has just been clicked");}}
 ); 
 ~~~
 
@@ -55,9 +56,9 @@ To cancel some event you should return **false** within the appropriate event ha
 Cancelling the event handler
 }}
 ~~~js
-var myEvent = $$("dataTableId").attachEvent("onBeforeTabClick", function (){
-    ...// some event handler code
-    return false;
+var myEvent = $$("dataTableId").attachEvent("onBeforeTabClick", function () {
+  ... // some event handler code
+  return false;
 })
 ~~~
 
@@ -73,8 +74,8 @@ Btw, using the **id** of a sub-element you can access a data item associated wit
 Referring within the event handler
 }}
 ~~~js
-$$("myTable").attachEvent("onafterselect",function(id){
-    $$("top_label").setValue(this.getItem(id).name)
+$$("myTable").attachEvent("onafterselect",function (id) {
+  $$("top_label").setValue(this.getItem(id).name)
 })
 ~~~
 

--- a/data/datatree/dynamic_loading.md
+++ b/data/datatree/dynamic_loading.md
@@ -1,111 +1,115 @@
-Dynamic Loading for Hierarchical Structures
-=====================================
+Dynamic Loading for Hierarchical Data Structures
+================================================
 
 {{note
-Here dynamic loading for [tree](datatree/index.md), [treetable](desktop/treetable.md) and [TreeCollection](api/refs/treecollection.md) is explored. 
-Switch to the main [Dynamic Loading](desktop/dynamic_loading.md) article, if needed.
+This article discusses dynamic loading for [tree](datatree/index.md), [treetable](desktop/treetable.md) and [TreeCollection](api/refs/treecollection.md).
+Refer to the main [Dynamic Loading](desktop/dynamic_loading.md) article if needed.
 }}
 
-Data can be loaded to hierarchical components in portions: 
+Data can be loaded dynamically into hierarchical components as follows:
 
-- Firstly, top parent nodes are loaded and they are initially collapsed;
-- Then, data is loaded to the node the moment it is expanded. 
+- First, the top parent nodes are loaded. Initially, they are collapsed (unless their `open` property is true).
+- Then, data is loaded under each node when it is expanded.
 
 ~~~js
 var tree = webix.ui({
-	url:"data/data_dyn.php"
+  view: "tree",
+  url: "data/data_dyn.php"
 }); 
-//or
+// or
+var tree = webix.ui({});
 tree.load("data/data_dyn.php");
 ~~~
 
-Dynamic loading can be implemented in different way, each of which is described below: 
+By default, Webix expects JSON data. The server can also return XML - see [Loading Tree Data](datatree/loading_data.md).
 
-##Using webix_kids flag 
+Dynamic loading can be implemented in three different ways:
 
-You can supply each parent data item with the **webix_kids** flag that indicates that this node can take child data and then watch how requests are sent
-automatically at the moment user expands the node. 
+- by setting the `webix_kids` property to `true` on nodes that are expected to have children
+- by calling the `[loadBranch()](api/treedataloader_loadbranch.md)` method
+- by setting a custom handler for the `onDataRequest` event
 
-~~~js
-var tree = webix.ui({
-	url:"data/data_dyn.php",
-});
-//or
-tree.load("data/data_dyn.php");
-~~~
+##Using the webix_kids flag
 
-Parent data items should look like this: 
-
-~~~js
-{ id:"1", value:"Branch", webix_kids:true}
-~~~
-
-The request URL during dunamic loading will be generated automatically on the base of the URL used by the component initially - **"data/data_json.php?continue=true&parent=1"** where: 
-
-- **parent** - ID of the node that has just been opened;
-- **continue** - flag indicating that it is an auto-formed URL.
-
-Make sure that serverside script can handle both situations: initial loading and loading on the base of a parameter.
-
-You can check how it works with [ready-made ServerSide connectors](#dynamic_connector) (of course, custom scripts will work all the same here).
-
-##Using loadBranch function
-
-You can catch the **node expand event** ([onBeforeOpen](api/treeapi_onbeforeopen_event.md) or [onAfterOpen](api/treeapi_onafteropen_event.md)) 
-to load branch data with the help of a [same-name method](api/treedataloader_loadbranch.md): 
-
-Let's assume that we have initial data loaded in some of the ways:
+On parent data items that can have children, you can set the **webix_kids** flag to `true`. When the user expands these nodes, Webix will automatically
+send XHR requests to the server for more data.
 
 ~~~js
 webix.ui({
-     view:"tree",
-     data:[
-     	{id:1, value:"Layout Branch", webix_kids:true},
-     	{id:2, value:"Data Branch", webix_kids:true},
-     ],
-     on:{
-     	onBeforeOpen:function(id){
-     		//if children has not been loaded yet
-     		if(this.getItem(id).$count!==-1)
-     			this.loadBranch(id, null, "data/data_dyn_json.php");
-     	}
-     }
+  view: "tree",
+  url: "data/data_dyn.php",
+  data: [
+    // parent node below
+    { id: "1", value: "Branch", webix_kids: true }
+  ]
+});
+~~~
+
+Webix will automatically generate the request URL to dynamically load data, based on the `url` property specified when initializing the component - **"data/data_dyn.php?continue=true&parent=1"**, where:
+
+- **parent** - ID of the node that has just been opened;
+- **continue** - flag indicating that it is an auto-generated request.
+
+If `url` is specified, Webix will also make an initial request for that URL, without parameters. Make sure the server-side script can handle both situations:
+the initial loading of data (top-level parent nodes), and loading children under a given parent node.
+
+While you can write custom scripts for this, you can check the [ready-made ServerSide connectors](#dynamic_connector).
+
+##Using the `loadBranch()` function
+
+You can catch the **node expansion events** ([onBeforeOpen](api/treeapi_onbeforeopen_event.md) or [onAfterOpen](api/treeapi_onafteropen_event.md))
+to load branch data using the **api/treedataloader_loadbranch.md** method. Let's assume that we have initial data loaded:
+
+~~~js
+webix.ui({
+  view: "tree",
+  data: [
+    { id:1, value: "Layout Branch", webix_kids: true },
+    { id:2, value: "Data Branch", webix_kids: true },
+  ],
+  on: {
+    onBeforeOpen: function (id) {
+      // if children have not been loaded yet
+      if (this.getItem(id).$count === -1)
+        this.loadBranch(id, null, "data/data_dyn.php");  // null means no callback
+    }
+  }
 });
 ~~~
 
 {{sample 17_datatree/16_dyn_loading/02_load_branch.html}}
 
-The URL of the new request will be based on the datasource, either provided by the api/treedataloader_loadbranch.md method or the one used intially -  **"data/data__dyn_json.php?continue=true&parent=1"** - where: 
+The URL of the new request will be based on the `url` property of the tree, which can be overridden by the api/treedataloader_loadbranch.md method - **"data/data__dyn.php?continue=true&parent=1"**. The parameters are the same as above:
 
 - **parent** - ID of the node that has just been opened;
-- **continue** - flag indicating that it is an auto-formed URL.
+- **continue** - flag indicating that it is an auto-generated request.
 
-If you need to use the same datasource, omit the last parameter of the *loadBranch()* method: 
+If you want to use the same data source, omit the last parameter to `loadBranch()`:
 
 ~~~js
 var tree = webix.ui({
-	view:"tree",
-    url:"data/data_dyn.php"
+  view: "tree",
+  url: "data/data_dyn.php",
+  ...
 });
-//or tree.load();
 
-tree.loadBranch(id); //"data/data_dyn.php" will be used
+this.loadBranch(id, null);  // "data/data_dyn.php" will be used
 ~~~
 
-Be sure the branch data you get is returned with **parent** and **data** properties. For JSON the returned data looks like this:
+Be sure the branch data sent by the server is an object with **parent** and **data** properties. A JSON response should look like this:
 
 ~~~js
-{ parent:1, data:[ ..array of child items..]}
+{ parent: 1, data: [ ...array of child items... ] }
 ~~~
 
 ##Redefining onDataRequestEvent
 
-Catch the **api/treedataloader_ondatarequest_event.md** event to redefine default dynamic loading behaviour and use any resired method to get the data from servserside:
+Set the **api/treedataloader_ondatarequest_event.md** event handler to redefine the default dynamic loading behaviour and use any desired method to get the data from the server:
 
-The [event](api/link/ui.tree_ondatarequest_event.md) fires when user expands a node that features **webix_kids** flag among its properties: 
+The [event](api/link/ui.tree_ondatarequest_event.md) fires when the user expands a node that has the **webix_kids** property set:
 
 ~~~js
-{ id:"1", value:"Layout Branch", webix_kids:true}
+{ id: "1", value: "Layout Branch", webix_kids: true }
 ~~~
 
 As it is stated above, this event triggers dynamic loading. In other words, if a component features a datasource (defined either by 
@@ -117,23 +121,23 @@ Let's assume that we have initial data loaded in some of the ways:
 
 ~~~js
 webix.ui({
-     view:"tree",
-     data:[
-     	{id:1, value:"Layout Branch", webix_kids:true},
-     	{id:2, value:"Data Branch", webix_kids:true},
+  view: "tree",
+  data: [
+    { id: 1, value: "Layout Branch", webix_kids: true },
+    { id: 2, value: "Data Branch", webix_kids: true },
      ],
-	on: {
-    	onDataRequest: function (id) {
-    		webix.message("Getting children of " + id);
-    		this.parse(
-    			webix.ajax().get("data/data_dyn_json.php?parent="+id).then(function (data) {
-    				return data = data.json();
-    			})
-    		);
-            //cancelling default behaviour
-    		return false;
-    	}
+  on: {
+    onDataRequest: function (id) {
+    webix.message("Getting children of " + id);
+    this.parse(
+      webix.ajax().get("data/data_dyn_json.php?parent=" + id).then(function (data) {
+        return data = data.json();
+      })
+    );
+    // cancelling default behaviour
+    return false;
     }
+  }
 });    
 ~~~
 
@@ -150,38 +154,38 @@ Be sure the branch data you get is returned with **parent** and **data** propert
 
 ##Dynamic Loading with ServerSide Connectors {#dynamic_connector}
 
-In case you use [Data Connector](http://docs.dhtmlx.com/connector__index.html) to load data from a database into tree or treetable dynamically, 
+In case you use [Data Connector](http://docs.dhtmlx.com/connector__index.html) to load data from a database into a Tree or TreeTable dynamically,
 you should call **dynamic_loading()** on the server side: 
 
 {{snippet
-Dynamic loading from db. Server-side code
+Dynamic loading from a server database. Server-side code.
 }}
 ~~~php
-require_once("../connector-php/codebase/data_connector.php");//includes the connector file
-$conn = mysql_connect('localhost', "root","");// creates a connection
+require_once("../connector-php/codebase/data_connector.php");  // includes the connector file
+$conn = mysql_connect('localhost', "root","");  // creates a connection
 mysql_select_db("sampleDB");// selects a database
 
-$data = new TreeDataConnector($conn, "MySQL");//initializes the connector object
-$data->dynamic_loading(30);//enables dynamic loading 
-//loads data from the specified database table 
-$data->render_table("packages_tree","id","value, state","","parent_id");    
+$data = new TreeDataConnector($conn, "MySQL");  // initializes the connector object
+$data->dynamic_loading(30);  // enables dynamic loading
+// loads data from the specified database table
+$data->render_table("packages_tree", "id", "value, state", "", "parent_id");
 ~~~
 
 
 Note, inside **dynamic_loading()** you should specify a number of records that will be loaded at once.
 
-All remaining stuff is the same as in case of [usual loading from a database](datatree/loading_data.md#loadingfromadatabase).
+Everything else is the same as in case of [usual loading from a database](datatree/loading_data.md#loadingfromadatabase).
 
 {{snippet
-Dynamic loading from db. Client-side code 
+Dynamic loading from the server. Client-side code.
 }}
 ~~~js
 webix.ui({
-	url:"data/data_dyn.php"
+  url: "data/data_dyn.php"
 });    
 ~~~
 
-Note that each data item is supplied with **webix_kids** flag to ensure dynamic loading.
+Note that each data item is supplied with the **webix_kids** flag to ensure dynamic loading.
 
 {{sample 17_datatree/16_dyn_loading/01_dyn_loading.html }}
 

--- a/data/datatree/events_handling.md
+++ b/data/datatree/events_handling.md
@@ -1,5 +1,5 @@
-Events handling
-=========================================
+Event handling with Tree
+=========================
 Tree supports various events that can be used to provide a custom behaviour for your tree.
 
 There are 2 ways you can add a handler to the event:
@@ -20,12 +20,13 @@ You can attach several handlers to the same event and detach them using two resp
 A general way to attach/detach the event handler
 }}
 ~~~js
-//to attach event
-	var myEvent = $$("treeId").attachEvent("onItemClick", function (){
-		//event handler code
-	})
+// to attach event
+var myEvent = $$("treeId").attachEvent("onItemClick", function () {
+// event handler code
+})
+
 //to detach event
-	$$("treeId").detachEvent(myEvent);
+$$("treeId").detachEvent(myEvent);
 ~~~
 
 Parameter 'on'
@@ -38,9 +39,9 @@ Attaching the event handler through parameter 'on'
 }}
 ~~~js
 webix.ui({
-	 view:"tree", 
-         ...
-	 on:{"itemClick": function(){alert("item has just been clicked");}}
+  view:"tree",
+  ...
+  on: {"itemClick": function () {alert("item has just been clicked");}}
 ); 
 ~~~
 
@@ -54,9 +55,9 @@ To cancel some event you should return **false** within the appropriate event ha
 Cancelling the event handler
 }}
 ~~~js
-var myEvent = $$("treeId").attachEvent("onBeforeTabClick", function (){
-    ...// some event handler code
-    return false;
+var myEvent = $$("treeId").attachEvent("onBeforeTabClick", function () {
+  ... // some event handler code
+  return false;
 })
 ~~~
 
@@ -73,7 +74,7 @@ Referring within the event handler
 }}
 ~~~js
 $$("treeId").attachEvent("onAfterSelect",function(id){
-    parentId = this.getItem(id).parent;
+  parentId = this.getItem(id).parent;
 })
 ~~~
 

--- a/data/datatree/loading_data.md
+++ b/data/datatree/loading_data.md
@@ -1,5 +1,5 @@
 Loading data
-====================
+============
 
 Webix Tree can get data in the following predefined [data formats](desktop/data_types.md):
 
@@ -8,70 +8,44 @@ Webix Tree can get data in the following predefined [data formats](desktop/data_
 
 *[Details and  examples of data formats](datatree/data_formats.md) in tree-like structures*
 
+There are two main ways you can specify the data source for Tree:
 
-There are 2 main ways you can specify data source for Tree:
+1. Define the data set in the object initialization;
+2. Use one of the api/link/ui.tree_parse.md or api/link/ui.tree_load.md methods.
 
-1. To define the data set in the object constructor; 
-2. To use api/link/ui.tree_parse.md or api/link/ui.tree_load.md method.
-
-Both ways lead to one and the same result and don't have any specificity.
+Both methods lead to the same result.
 
 {{note
-If you load XML data you need to set  the api/link/ui.tree_datatype_config.md property in the constructor config or the second parameter of the 
+If you load XML data you need to set the api/link/ui.tree_datatype_config.md property in the constructor config or the second parameter of the
 api/link/ui.tree_parse.md / api/link/ui.tree_load.md method to the name of the expected data type, i.e. 'xml'.
 }}
 
-{{snippet
-	Loading data to the tree
-}}
-~~~
-var treedata= [
-	{ id:"1", value:"Book 1", data:[
-			{ id:"1.1", value:"Part 1" },
-			{ id:"1.2", value:"Part 2" }
-	]}
-];
-tree = new webix.ui({
-	view:"tree",
-	...
-    data: treedata
-}); 
-
-//or
-tree.parse(treedata);
-~~~
-{{sample
-	17_datatree/01_loading/01_json_data.html
-}}
-
-
-
 Loading from inline dataset
 -----------------------------------------
-If you want to specify the data set directly on the page, you can  use:
+If you want to specify the data set directly on the page, you can use:
 
 1. property api/link/ui.tree_data_config.md 
 2. method api/link/ui.tree_parse.md 
 
 
 {{snippet
-Specifying data on the page
+Specifying data inline
 }}
 ~~~js
 treedata = [
-		{ id:"1", value:"Book 1", data:[
-				{ id:"1.1", value:"Part 1" },
-				{ id:"1.2", value:"Part 2" }
-		]},
-		{ id:"2", value:"Book 2", data:[
-				{ id:"2.1", value:"Part 1" }
-		]}
+  { id: "1", value: "Book 1", data: [
+    { id: "1.1", value: "Part 1" },
+    { id: "1.2", value: "Part 2" }
+  ]},
+  { id: "2", value: "Book 2", data: [
+    { id: "2.1", value: "Part 1" }
+  ]}
 ];
 
 tree = new webix.ui({
-	view:"tree",
-    ...
-	data: treedata
+  view: "tree",
+  ...
+  data: treedata
 });
 
 //or 
@@ -81,46 +55,43 @@ tree.parse(treedata)
 
 
 Loading from a data file
--------------------------------------
-To load data from a file, you can use:
+------------------------
+To load data from a file on the server, you can use:
 
 1. property api/link/ui.tree_url_config.md 
 2. method api/link/ui.tree_load.md
 
-Remember, in case of XML data you should specify the data type in the api.
+Remember, in case of XML data you should specify the data type explicitly as 'xml':
 
 ~~~js
 tree = new webix.ui({
-	view:"tree",
-	...
-    url:"data/data.xml".
-    datatype:"xml"
-
-}); 
+  view: "tree",
+  ...
+  url: "data/data.xml",
+  datatype: "xml"
+});
 //or
-tree.load('data/data.xml', 'xml')
+tree.load('data/data.xml', 'xml');
 ~~~
 {{sample 17_datatree/01_loading/01_json_data.html}}
 
-Loading plain (list-like) data 
--------------------------------------------------------------------
-There is a possibility to load plain (list-like) data into the tree. The required tree-like format for such a data is achieved by means of grouping. 
-
-Grouping is specified through the **$group** key of the api/link/ui.tree_scheme_config.md parameter.
+Loading linear (list-like) data
+-------------------------------
+It's possible to load plain (list-like) data into the tree. The tree structure is achieved by means of grouping. Grouping is specified through the **$group** key of the api/link/ui.tree_scheme_config.md parameter.
 
 ~~~js
 tree = new webix.ui({
-	view:"tree",
-	scheme:{
-		$group:"#make#",
-	},
-	data: [
-		{ id:1, value:"Avalon", make:"Toyota"},
-		{ id:2, value:"Corolla", make:"Toyota"},
-		{ id:3, value:"Camry", make:"Toyota"},
-		{ id:4, value:"Octavia", make:"Skoda"},
-		{ id:5, value:"Superb", make:"Skoda"}
-	]
+  view: "tree",
+  scheme: {
+    $group: "#make#",
+  },
+  data: [
+    { id: 1, value: "Avalon", make: "Toyota" },
+    { id: 2, value: "Corolla", make: "Toyota" },
+    { id: 3, value: "Camry", make: "Toyota" },
+    { id: 4, value: "Octavia", make: "Skoda" },
+    { id: 5, value: "Superb", make: "Skoda" }
+  ]
 });
 ~~~
 
@@ -129,22 +100,22 @@ tree = new webix.ui({
 }}
 
 Loading from a database
--------------------------
+-----------------------
 
-To load data from database table(s) you should deal with both client and server sides. 
+To load data from a database on the server you should deal with both client and server sides.
 
 **On the client side**
 
-- you should either define an [url](api/link/ui.tree_url_config.md) property or call the [load](api/link/ui.tree_load.md) method that would 
-point to a file that implements  server-side communication. 
+You should either define a [url](api/link/ui.tree_url_config.md) property or call the [load](api/link/ui.tree_load.md) method that would
+point to a server REST API endpoint.
 
 {{snippet
-Static loading from db. Client-side code.
+Static loading from a server database. Client-side code.
 }}
 ~~~js
 tree = new webix.ui({
-    ...
-	url:"data/tree_data.php"
+  ...
+  url: "data/tree_data.php"
 }); 
 //or
 tree.load("data/tree_data.php");
@@ -152,21 +123,21 @@ tree.load("data/tree_data.php");
 
 **On the server side**
 
-- you can write full server logic by yourself;
-- or use <a href="http://docs.dhtmlx.com/connector__php__index.html">dhtmlxConnector</a>
+- you can write the server logic by yourself;
+- or you can use <a href="http://docs.dhtmlx.com/connector__php__index.html">dhtmlxConnector</a>
 
-In case of using dhtmlxConnector the related server-side script will look like this:
+If using dhtmlxConnector, the related server-side script will look like this:
 
 {{snippet
-Static loading from db. Server-side code
+Static loading from a MySQL database on the server. Server-side code.
 }}
 ~~~php
-require_once("../connector-php/codebase/data_connector.php");//includes the connector file
-$conn = mysql_connect('localhost', "root","");//creates a connection
-mysql_select_db("sampleDB");// selects a database
+require_once("../connector-php/codebase/data_connector.php");  // includes the connector file
+$conn = mysql_connect('localhost', "root","");  // creates a connection
+mysql_select_db("sampleDB");  // selects a database
 
-$data = new TreeDataConnector($conn, "MySQL");//initializes the connector object
-//loads data from the specified database table 
+$data = new TreeDataConnector($conn, "MySQL");  //initializes the connector object
+// loads data from the specified database table
 $data->render_table("packages_tree","id","value, state","","parent_id");
 ~~~
 

--- a/data/datatree/selection.md
+++ b/data/datatree/selection.md
@@ -4,16 +4,16 @@ Tree provides an ability to select leaves and branches within it.
 
 Single-item selection
 ---------------------------
-By default, selection is disabled in Tree. To activate it you should set parameter api/link/ui.treetable_select_config.md to *true*.
+By default, selection is disabled in Tree. To activate it you should set the api/link/ui.treetable_select_config.md parameter to *true*.
 
 {{snippet
 Enabling selection in Tree
 }}
 ~~~js
 tree = new webix.ui({
-	view:"tree",
-    ...
-    select:true
+  view: "tree",
+  ...
+  select: true
 })
 ~~~
 
@@ -30,9 +30,9 @@ Enabling multi-selection in Tree
 }}
 ~~~js
 tree = new webix.ui({
-	view:"tree",
-    ...
-    select:'multiselect'
+  view: "tree",
+  ...
+  select: "multiselect"
 })
 ~~~
 

--- a/data/desktop/dynamic_loading.md
+++ b/data/desktop/dynamic_loading.md
@@ -1,41 +1,40 @@
 Dynamic Loading
-=====================
+===============
 
-Dynamic loading is all about loading data from server. It isn't connected with client side since it is enabled on server. Here data is loaded with the 
-help of a **php-script**. 
+Dynamic loading means loading data on request, from the server. For example, a PHP script could supply data dynamically
+to a Webix component.
 
 Dynamic loading is useful for long datasets since data populates the component in smaller portions. Initially data fills the view to some extent and 
-later on it is dynamically loaded each time you scroll up and down the view or switch between [pages](desktop/paging.md). 
+later on it is dynamically loaded each time you scroll up and down the view or switch among [pages](desktop/paging.md).
 
-For **plain structures** used in the majority of webix data components you can control the process by specifying: 
+For **linear structures** (used in the majority of Webix data components) you can control the process by specifying:
 
-- item position to start loading wiht;
-- how many data items should be loaded each time users scroll/page the element. 
+- the item position to start loading with;
+- how many data items should be loaded each time the user scrolls/pages the element.
 
-Continue reading the  desktop/plain_dynamic_loading.md article.
+Read more at desktop/plain_dynamic_loading.md.
 
-For **hierarchical structures** like [tree](datatree/index.md) and [treetable](desktop/treetable.md) you can specify: 
+For **hierarchical structures** like [Tree](datatree/index.md) and [TreeTable](desktop/treetable.md) you can specify:
 
 - the node ID for which you need to load child data.
 
-Continue reading the  datatree/dynamic_loading.md article. 
+Read more at datatree/dynamic_loading.md.
 
 {{note
-Note that dynamic loading works only in case this functionality is **enabled on server**. If not, any communication between client and server is senseless 
-since all data has already been loaded the moment you inilialize the component. 
+Note that dynamic loading works only if the functionality is **supported by the server**.
 }}
 
-Here's a sample how dynamic loading can be enabled using [ServerSide Connectors](desktop/dataconnector.md). 
+Here's an example of dynamic loading using [ServerSide Connectors](desktop/dataconnector.md).
 
 {{snippet
 Server Script "data_dyn.php"-file
 }}
 ~~~php
 <?php
-   require_once("../../common/config.php");
-   $data = new JSONDataConnector($conn, $dbtype);
-   $data->dynamic_loading(30); // the number of records loaded initially
-   $data->render_table("packages_plain","id","package, size, architecture, section");
+  require_once("../../common/config.php");
+  $data = new JSONDataConnector($conn, $dbtype);
+  $data->dynamic_loading(30);  // the number of records loaded initially
+  $data->render_table("packages_plain", "id", "package, size, architecture, section");
 ?>
 ~~~
 
@@ -45,6 +44,6 @@ Server Script "data_dyn.php"-file
 
 @index: 
 	desktop/plain_dynamic_loading.md
-    datatree/dynamic_loading.md
+	datatree/dynamic_loading.md
 
 @complexity:2

--- a/data/desktop/multiview.md
+++ b/data/desktop/multiview.md
@@ -9,10 +9,10 @@ Multiview
 
 ##Overview
 
-Multiview  helps you rationally use space on the page by placing different views into one and the same area. Only one view is visible at a time the others accessable with the help of dedicated buttons. 
+Multiview helps you efficiently use space on the page by placing different views into one and the same area. Only one view is visible at a time. The others are accessible with the help of dedicated buttons.
 
 Multiview inherits from [layout](desktop/layout.md) and if combined with a switching control like a [tabbar](desktop/controls.md#tabbar),
-form a [tabview](desktop/tabview.md).
+forms a [tabview](desktop/tabview.md).
 
 <br>
 
@@ -26,12 +26,12 @@ Multiview with three views
 }}
 ~~~js
 webix.ui({
-	view:"multiview", 
-	cells:[
-         {id:"listView", view:"list", .... },
-         {id:"formView", view:"htmlform", .... },
-         {id:"emptyView"}
-    ]
+  view: "multiview",
+  cells: [
+    {id: "listView", view: "list", .... },
+    {id: "formView", view: "htmlform", .... },
+    {id: "emptyView" }
+  ]
 });
 ~~~
 
@@ -45,11 +45,11 @@ The direct initialization of the component (**view:"multiview"**) is optional an
 
 ~~~js
 webix.ui({
-	cells:[
-         {id:"listView", view:"list", .... },
-         {id:"formView", view:"htmlform", .... },
-         {id:"emptyView"}
-    ]
+  cells:[
+    {id: "listView", view: "list", .... },
+    {id: "formView", view: "htmlform", .... },
+    {id: "emptyView"}
+  ]
 });
 ~~~
 
@@ -61,9 +61,9 @@ The **dimensions** of multiview cells are adjusted to their content. By default,
 
 ~~~js
 webix.ui({
-	view:"multiview", 
-	cells:[],
-    fitBiggest:true
+  view: "multiview",
+  cells: [],
+  fitBiggest:true
 });
 ~~~
 
@@ -73,9 +73,9 @@ My default multiview cells are switched with horizontal animation of a "slide" t
 
 ~~~js
 webix.ui({
-	view:"multiview", 
-	cells:[],
-    animate:false
+  view: "multiview",
+  cells: [],
+  animate:false
 });
 ~~~
 
@@ -118,3 +118,4 @@ Learn how to "memorize" the currenty opened tab in the [related article](desktop
 @index:
   - desktop/tabbar_switching.md
   - desktop/show_switching.md
+  

--- a/data/desktop/pivot.md
+++ b/data/desktop/pivot.md
@@ -101,15 +101,15 @@ The initialization of Pivot doesn't differ from that of other [Webix components]
 
 ~~~js
 webix.ui({
-  view:"pivot",
-    container:"testA", 
-  id:"pivot",
-    max:true,
+  view: "pivot",
+  container: "testA",
+  id: "pivot",
+  max: true,
   structure: { 
     rows: ["form", "name"],
     columns: ["year"],
-    values: [{ name:"gdp", operation:"sum"}, { name:"oil", operation:"sum"}],
-    filters:[]
+    values: [{ name: "gdp", operation: "sum"}, { name: "oil", operation: "sum"}],
+    filters: []
   }
 });
 ~~~
@@ -143,8 +143,8 @@ Inline Data (JSON)
 }}
 ~~~js
 var pivot_dataset = [
- {"name": "China", "year": 2005, "form": "Republic", "gdp": 181.357, "oil": 1.545},
- {"name": "China", "year": 2006, "form": "Republic", "gdp": 212.507, "oil": 1.732},
+  {"name": "China", "year": 2005, "form": "Republic", "gdp": 181.357, "oil": 1.545 },
+  {"name": "China", "year": 2006, "form": "Republic", "gdp": 212.507, "oil": 1.732 },
  ...
 ]
 ~~~
@@ -153,9 +153,9 @@ To load inline data during component init, make use of api/link/dataloader_data_
 
 ~~~js
 webix.ui({
-  view:"pivot",
-    id:"pivot",
-  data:pivot_dataset
+  view: "pivot",
+  id: "pivot",
+  data: pivot_dataset
 });
 ~~~
 
@@ -173,8 +173,8 @@ Either you get data from an external file or by a serverside script, you should 
 If you load the data during component init, specify the path to this file/script as value of api/link/dataloader_url_config.md
 
 ~~~js
-view:"pivot",
-url:"../load.php" // or "../data.json"
+view: "pivot",
+url: "../load.php" // or "../data.json"
 ~~~
 
 
@@ -197,12 +197,12 @@ Configuring Pivot
 Operations are set within [Pivot structure object](#struct) in **values** array. **Name** refers to data item property:
 
 ~~~js
-view:"pivot",
-structure:{
-  values:[
-      { name:"gdp", operation:"sum"}, //gdp values will be summed
-        { name:"oil", operation:"max"} //max oil value will be shown
-    ]
+view: "pivot",
+structure: {
+  values: [
+    { name: "gdp", operation: "sum" }, //gdp values will be summed
+    { name: "oil", operation: "max" } //max oil value will be shown
+  ]
 }
 ~~~
 
@@ -217,14 +217,14 @@ If needed, you can **add your own operation**: {#operation}
 
 ~~~js
 pivot.operations.abssum = function(data) {
-    //data - array of values which need to be processed
-    var sum = 0;
-    for (var i = 0; i < data.length; i++) {
-       var num = window.parseFloat(data[i], 10);
-       if (!window.isNaN(num))
-          sum += Math.abs(num);
-       }
-    return sum;
+  // data - array of values which need to be processed
+  var sum = 0;
+  for (var i = 0; i < data.length; i++) {
+    var num = window.parseFloat(data[i], 10);
+    if (!window.isNaN(num))
+      sum += Math.abs(num);
+  }
+  return sum;
 };
 ~~~
 
@@ -242,11 +242,11 @@ Filters are set within [Pivot structure object](#struct) in **filters** array. *
 
 ~~~js
 view:"pivot",
-structure:{
-  values:[
-    {name:"name",type:"select"},
-        {name:"continent", type:"text"}
-    ]
+structure: {
+  values: [
+    { name: "name", type:"select" },
+    { name: "continent", type: "text" }
+  ]
 }
 ~~~
 
@@ -268,8 +268,8 @@ In this case, you can use **fieldMap** property to set beautiful names for colum
 
 ~~~js
 webix.ui({
-  view:"pivot",
-  fieldMap:{ "a1" : "GDP", "a2" : "Grow ratio" },
+  view: "pivot",
+  fieldMap: { "a1" : "GDP", "a2" : "Grow ratio" },
   ...
 });
 ~~~
@@ -321,10 +321,10 @@ Format of a **config** object is the same as "structure" parameter of the constr
 
 ~~~js
 var config = {
-    rows: ["form", "name"],
-    columns: ["year"],
-    values: [{ name:"gdp", operation:"sum"}, { name:"oil", operation:"sum"}],
-    filters:[]
+  rows: ["form", "name"],
+  columns: ["year"],
+  values: [{ name: "gdp", operation: "sum"}, { name: "oil", operation: "sum"}],
+  filters:[]
 }
 ~~~
 
@@ -351,10 +351,11 @@ This allows you use any of datatable [events](api/refs/ui.datatable_events.md) o
 
 ~~~js
 //attach event to selection
-datatable.attachEvent("onAfterSelect", function(id){ 
-    webix.message("selected row: "+id); 
+datatable.attachEvent("onAfterSelect", function (id) {
+  webix.message("selected row: "+id);
+});  
 });
 
 //or get the ID of the currently selected item.
-var sel = datatable.getSelection();
+var sel = datatable.getSelectedId();
 ~~~

--- a/data/desktop/plain_dynamic_loading.md
+++ b/data/desktop/plain_dynamic_loading.md
@@ -1,28 +1,28 @@
-Dynamic Loading for Plain Structures
-==========================
+Dynamic Loading for Linear Structures
+=====================================
 
-Data can be loaded to non-hierarchical components in portions:
+Data can be loaded into non-hierarchical components in chunks:
 
-- Firstly, a limited number of record is loaded;
+- First, a limited number of record is loaded;
 - Then, data is loaded at the moment when: 
-	- user scrolls the component;
-    - user switches to the new page within the component (in case [pager](desktop/paging.md) is defined).
+    - the user scrolls the component;
+    - the user switches to the new page within the component (in case [pager](desktop/paging.md) is defined).
 
 ##Configuring Dynamic Loading Behavior
 
 To enable dynamic data loading you need: 
 
-- to set the component datasource that will load initial data. It can be done either with the help of api/atomdataloader_url_config.md or api/atomdataloader_load.md method. 
-- to define varous aspect of dynamic loading such as api/virtualrenderstack_loadahead_config.md, api/virtualrenderstack_datafetch_config.md and api/link/ui.proto_datathrottle_config.md. 
+- to set the component datasource that will load initial data. It can be done either with the help of api/atomdataloader_url_config.md or the api/atomdataloader_load.md method.
+- to define various aspects of dynamic loading such as api/virtualrenderstack_loadahead_config.md, api/virtualrenderstack_datafetch_config.md and api/link/ui.proto_datathrottle_config.md.
 
 ~~~js
 webix.ui({
-	view:"dataview", // any data-presenting component
-    datatype:"..",
-    url:"data/data_dyn.php",
-    datafetch:50,
-    datathrottle: 100,
-    loadahead:50
+  view: "dataview",  // any data-presenting component
+  datatype: "...",
+  url: "data/data_dyn.php",
+  datafetch: 50,
+  datathrottle: 200,
+  loadahead: 50
 });
 ~~~
 
@@ -30,12 +30,12 @@ webix.ui({
 
 - **datafetch** (number) - defines the start position of loading. In the sample above, the items will be loaded beginning with the fiftieth one;
 {{sample 06_dataview/16_dyn_loading/03_datafetch.html }}
-- **datathrottle** (number) - defines the interval in milliseconds between data requests. It means that when you scroll slowly, the server wouldn't be 
-overloaded with requests, since they are triggered only once in 200 milliseconds(as it goes in the code piece above);
+- **datathrottle** (number) - defines the interval in milliseconds between data requests. It means that if you scroll slowly, the server won't be
+overloaded with requests, since they are triggered only once every 200 milliseconds (as defined in the code above);
 {{sample 06_dataview/16_dyn_loading/04_datathrottle.html }}
 - **loadahead** (number) - defines the number of items to be loaded each time as you scroll down or up the view, or switch to the next page; {{sample 15_datatable/16_dyn_loading/04_db_dyn_loadahead.html }}
 
-When scolling or pagination occurs, the component will automatically isuue a request based on the datasourse, e.g. **"data/data_dyn.php?continue=true&count=100&start=130"** where: 
+When scrolling or pagination occurs, the component will automatically issue a request based on the datasource, e.g. **"data/data_dyn.php?continue=true&count=100&start=130"** where:
 
 - **continue** - is a flag that indicates that this request was formed automatically;
 - **count** - is a value of datathrottle parameter;
@@ -45,20 +45,20 @@ When scolling or pagination occurs, the component will automatically isuue a req
 Note that your server script should be able to handle these parameters.
 }}
 
-##Dynamic Loading by Api
+##Dynamic Loading via API calls
 
 The **api/link/ui.datatable_loadnext.md** method can be used to send a request to load the specified number of records and show them in the component. The arguments are:
 
-- the **number of records** that will be loaded on function execution; 
+- the **number of records** that will be loaded;
 - the **start position** to insert;
 - **callback** (*null* if you don't need it);
-- the **loading url** (if it wasn't specified in the component constructor);
-- boolean **'now' flag** to ignore datathrottle and load files immediately on *loadNext()* executiion. 
+- the **loading URL** (if it wasn't specified in the component constructor);
+- boolean **`now` flag** to ignore datathrottle and load files immediately when *loadNext()* is executed.
 
 ~~~js
-grida.loadNext(10,0,null,"data/data.php"); //uses given url
+grida.loadNext(10, 0, null, "data/data.php");  // uses given URL
 
-grida.loadNext(10, 0); //uses url set in the component constructor
+grida.loadNext(10, 0);  //uses the URL specified in the component constructor
 ~~~
 
 The method allows for the following scenarios: 
@@ -66,7 +66,7 @@ The method allows for the following scenarios:
 - new data may be added to the end of current component data: 
 
 ~~~js
-grida.loadNext(10,0,null,"data/data.php");
+grida.loadNext(10, 0, null, "data/data.php");
 ~~~
 
 {{sample 15_datatable/16_dyn_loading/05_load_next_add.html }}
@@ -80,15 +80,15 @@ grida.loadNext(10, 0, null,"data/data.php");
 
 {{sample 15_datatable/16_dyn_loading/06_load_next_replace.html}}
 
-- data can be loaded from the specified position while further scrolling or paging will result in serverside requests for the needed data.
+- data can be loaded from the specified position while further scrolling or paging will result in requests to the server for the required data.
 
 ~~~js
 var gridb = webix.ui({
-	view:"datatable", 
-    dfatafetch:50,
-    ready:function(){
-		this.showItemByIndex(900);
-	}
+  view: "datatable",
+  dfatafetch: 50,
+  ready: function () {
+    this.showItemByIndex(900);
+  }
 });
 gridb.loadNext(50,900,null,"data/data_dyn.php");
 ~~~

--- a/data/desktop/tabview.md
+++ b/data/desktop/tabview.md
@@ -9,7 +9,7 @@ Tabview
 
 ##Overview
 
-Tabview is a **hybrid** component that is made of a [multiview](desktop/multiview.md) and [tabbar](desktop/controls.md#tabbar). 
+Tabview is a **hybrid** component that is made of a [multiview](desktop/multiview.md) and [tabbar](desktop/controls.md#tabbar).
 
 Tabview allows for quick initialization of a multiview with a built-in ability to [switch between the views](desktop/tabbar_switching.md).
 
@@ -29,21 +29,23 @@ Tabview
 }}
 ~~~js
 webix.ui({
-	view:"tabview",
-	cells:[
-		{
-		 header:"List",
-		 body:{
-			id:"listView",
-			view:"list", ...
-		}},
-        {
-		 header:"Form",
-		 body:{
-			id:"formView",
-			view:"form", ...
-		}}
-	]
+  view: "tabview",
+  cells: [
+    {
+      header: "List",
+      body: {
+        id: "listView",
+        view: "list", ...
+      }
+    },
+    {
+      header: "Form",
+      body: {
+        id: "formView",
+        view: "form", ...
+      }
+    }
+  ]
 });
 ~~~
 {{sample 02_toolbar/03_tabview.html }}
@@ -60,11 +62,11 @@ Note that switching between views is enabled automatically via a [tabbar](deskto
 
 ##Working with Tabview
 
-Hybrid nature of a tabview allows configuring each of its parts separately:
+The hybrid nature of a tabview allows configuring each of its parts separately:
 
-- though the same-name object properties in the initial configuration:
+- through the same-name object properties in the initial configuration:
 
-These  configuration objects may contain native properties of [multiview](desktop/multiview.md) and [tabbar](desktop/controls.md#tabbar)
+These configuration objects may contain native properties of [multiview](desktop/multiview.md) and [tabbar](desktop/controls.md#tabbar)
 that need to be redefined. If the configurations are omitted, default values will be used. 
 
 ~~~js
@@ -111,12 +113,12 @@ The **animate** property may take an object with [advanced animation settings](d
 Icons for the tabbar tabs are set via additional HTML in the tab **header**:
 
 ~~~js
-view:"tabview",
-cells:[
-	{ header:"<span class='webix_icon fa-film'></span>List",
-	  body:{}
-    }
- ]   
+view: "tabview",
+cells: [
+  { header: "<span class='webix_icon fa-film'></span>List",
+    body:{}
+  }
+]
 ~~~
 
 {{sample 20_multiview/05_tabbar_with_icons.html}}
@@ -132,22 +134,22 @@ Closing functionality is a [tabbar](desktop/controls.md#tabbar) feature.
 To make all tabs closable, **close** property should be set to *true* in the **tabbar** configuration: 
 
 ~~~js
-view:"tabview",
-tabbar:{
-	close:true
+view: "tabview",
+tabbar: {
+  close:true
 }
 ~~~
 
 To make a separate tab closable, use the **close** proerty in its configuration: 
 
 ~~~js
-view:"tabview",
-cells:[
-	{ header:"List",
-      close:true,
-	  body:{...}
-    }
- ] 
+view: "tabview",
+cells: [
+  { header:"List",
+    close:true,
+    body:{...}
+  }
+]
 ~~~
 
 {{sample 20_multiview/11_close_button.html}}
@@ -161,25 +163,25 @@ Tabbar default feature. If the tabs are wider than the available space, some of 
 Everything is done fully automatically, though customization options for tab and popup width, icons, etc. are available through the **tabbar** configuration: 
 
 ~~~js
-view:"tabview",
-tabbar:{
-	popupWidth:300, 
-    tabMinWidth:120
+view: "tabview",
+tabbar: {
+  popupWidth: 300,
+  tabMinWidth: 120
 }
 ~~~
 
-Study the topic in detail in the dedicated [documentation article](desktop/responsive_tabbar.md). 
+More in detail in the dedicated [documentation article](desktop/responsive_tabbar.md).
 
 ###Adjusting tab dimensions
 
 The width of each tab can be set separately:
 
 ~~~js
-view:"tabview",
+view: "tabview",
 cells:[
-	{ header:"List", width:150, body:{...} },
-    { header:"Form", width:250, body:{...} },
- ] 
+  { header:"List", width:150, body:{...} },
+  { header:"Form", width:250, body:{...} },
+]
 ~~~
 
 If tabs are of different width and height, they usually take the size of the smallest tab once the user switches to it. 
@@ -187,9 +189,9 @@ If tabs are of different width and height, they usually take the size of the sma
 To avoid this behavior, you should use the **fitBiggest** property in the **multiview** configuration object: 
 
 ~~~js
-view:"tabview", 
-multiview:{ 
-	fitBiggest:true 
+view: "tabview",
+multiview: {
+  fitBiggest:true
 }
 ~~~
 
@@ -206,5 +208,3 @@ The functionality is described in detail in the desktop/tabs_options.md article.
 - desktop/show_switching.md
 - desktop/tabbar_switching.md
 - desktop/tabs_options.md
-
-

--- a/data/desktop/whats_new_1_4.md
+++ b/data/desktop/whats_new_1_4.md
@@ -19,7 +19,7 @@ Version 1.4
 - keyboard navigation for list component
 - correct sizing of layout with hidden pannels 
 - elementsConfig supported for nested collections
-- getSelection deprecated in favor of getSelectionId
+- getSelection deprecated in favor of getSelectedId
 - better styling for icon buttons
 - webix.onReady event
 - webix.ui.zindexBase property added

--- a/data/tutorials/basic_app_3.md
+++ b/data/tutorials/basic_app_3.md
@@ -25,11 +25,11 @@ The connector should be set as data **url** for a component.
 
 ~~~js
 {
- 	view:"list", id:"mylist",
-    template:"#title# - #year#",
-    select:true, 
-    url:"../common/connector.php",
-	datatype:"xml"
+  view: "list", id: "mylist",
+  template: "#title# - #year#",
+  select: true,
+  url: "../common/connector.php",
+  datatype: "xml"
 }
 ~~~
 
@@ -39,12 +39,12 @@ DataConnector enables only **server->client interaction**, it's the component's 
 
 **Webix.DataProcessor** is responsible for [server-side integration](desktop/serverside.md) and handles all the CRUD operations.
 
-It should be inited for the component you'd like to perform server work with: 
+It should be initialized for the component you'd like to perform server work with:
 
 ~~~js
 var dp = new webix.DataProcessor({
-	master:$$('mylist'),//specifies the desired component 
-	url:"../common/connector.php"// 
+  master: $$('mylist'),  // specifies the desired component
+  url: "../common/connector.php"  // specifies the server API endpoint
 });
 ~~~
 
@@ -64,17 +64,17 @@ The **update();** function is no longer needed as well since from now on we appl
 ~~~js
 
 webix.ui({
-	view:"toolbar", 
-    cols:[
-		{...},
-		{
-         view:"button", 
-         id:"update", 
-         value:"Save", 
-         width:100, 
-         click:"$$('myform').save()"
-        } 
-	]   //the new function for the button
+  view: "toolbar",
+  cols: [
+    {...},
+    {
+      view: "button",
+      id: "update",
+      value: "Save",
+      width: 100,
+      click: "$$('myform').save()"
+    }
+  ]  // the new function for the button
 });
 
 $$("myform").bind($$("mylist")); //component binding


### PR DESCRIPTION
Regarding commit 1e75c6a3e2d7c89bfa13a4bec73ff12aa18bfd76, how can we ensure a consistent use of tabs vs. spaces throughout the documentation (and codebase)?

The majority of JS code uses spaces (no tabs, because they can be rendered at arbitrary widths - 2, 4, 8), but regardless the choice, it would be good to be consistent about it.