### PR TITLE
Corrects missing parentheses on webix.once doc

### DIFF
--- a/data/api/_once.md
+++ b/data/api/_once.md
@@ -13,7 +13,7 @@ once
 
 datatable.attachEvent("onItemClick", webix.once(function(id){
     webix.message(id); //Will be shown only for the first click;
-});
+}));
 
 
 @template:	api_method


### PR DESCRIPTION
Example code had a missing parentheses. 