### PR TITLE
Adds buttons text to localisation doc

### DIFF
--- a/data/pivot/localization.md
+++ b/data/pivot/localization.md
@@ -1,7 +1,7 @@
 Localization
 ===============
 
-By default, all names and titles in Pivot are defined in English, but you can set any other language by specifying a custom locale for the page. 
+By default, all names and titles in Pivot are defined in English, but you can set any other language by specifying a custom locale for the page.
 
 ~~~js
 webix.i18n.pivot = {
@@ -18,8 +18,10 @@ webix.i18n.pivot = {
 	sum: "sum",
 	text: "text",
 	values: "Values",
-    windowTitle: "Pivot Configuration",
-	windowMessage: "[move fields into required sector]"
+  windowTitle: "Pivot Configuration",
+	windowMessage: "[move fields into required sector]",
+	apply: "Apply",
+	cancel: "Cancel"
 };
 
 // and then initialize Pivot and see your custom names


### PR DESCRIPTION
When searching for how to translate the pivot window's buttons, I couldn't find anything in the docs, although they're being used in [this example](http://docs.webix.com/samples/61_pivot/01_init/05_locale.html).